### PR TITLE
WURFL: Add Redis storage

### DIFF
--- a/WURFL/Storage/Redis.php
+++ b/WURFL/Storage/Redis.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Copyright (c) 2015 ScientiaMobile, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Refer to the COPYING.txt file distributed with this package.
+ *
+ * @category   WURFL
+ * @package	WURFL_Storage
+ * @copyright  ScientiaMobile, Inc.
+ * @license	GNU Affero General Public License
+ * @author	 Fantayeneh Asres Gizaw
+ * @version	$id$
+ */
+/**
+ * WURFL Storage
+ * @package	WURFL_Storage
+ */
+class WURFL_Storage_Redis extends WURFL_Storage_Base {
+
+    const EXTENSION_MODULE_NAME = "redis";
+
+    private $defaultParams = array(
+        "host" => "127.0.0.1",
+        "port" => "6379",
+        "hash_name" => 'WURFL_DATA',
+        "redis" => null,
+        "database" => 0,
+        "client" => "phpredis"
+    );
+
+    private $database;
+    private $host;
+    private $port;
+    private $redis;
+    private $hashName;
+    private $client;
+
+    protected $supports_secondary_caching = true;
+
+    public function __construct($params) {
+        $currentParams = is_array($params)? array_merge($this->defaultParams, $params): $this->defaultParams;
+        $this->initialize($currentParams);
+    }
+
+    private function checkRedisInstance($redis)
+    {
+        if (extension_loaded(self::EXTENSION_MODULE_NAME) && ($redis instanceof Redis)) {
+            return true;
+        }
+        if (class_exists('\Predis\Client') && ($redis instanceof \Predis\Client)) {
+            return true;
+        }
+        throw new WURFL_Storage_Exception(
+            'Connection object is not a Redis or a Predis\Client instance'
+        );
+    }
+
+
+    private function checkClient($client)
+    {
+        if (!in_array($client, array('phpredis', 'predis'))) {
+            throw new WURFL_Storage_Exception(
+                'Redis client must be phpredis or predis'
+            );
+        }
+
+        return $client;
+    }
+
+    private function buildRedisObject($client, $host, $port, $database = 0)
+    {
+        if ($client == 'phpredis') {
+            $redis = new Redis();
+            $redis->connect($host, $port);
+        } elseif ($client == 'predis') {
+            $redis = new Predis\Client(
+                array('scheme' => 'tcp', 'host'   => $host, 'port'   => $port)
+            );
+            $redis->connect();
+        }
+        if ($database) {
+            $redis->select($database);
+        }
+
+        return $redis;
+    }
+
+    public function initialize($params) {
+        $this->host = $params['host'];
+        $this->port = $params['port'];
+        $this->hashName = $params['hash_name'];
+        $this->database = $params['database'];
+        $this->client = $this->checkClient($params['client']);
+        if ((null !== $params['redis']) && $this->checkRedisInstance($params['redis'])) {
+            // when using this parameter, the Redis object has to be connected
+            // and with the correct database selected
+            $this->redis = $params['redis'];
+        } else {
+            $this->redis = $this->buildRedisObject(
+                $this->client,
+                $this->host,
+                $this->port,
+                $this->database
+            );
+        }
+    }
+
+    public function load($key) {
+        $value = $this->redis->hget($this->hashName, $key);
+
+        $returnValue = null;
+        if ($value !== false) {
+            $returnValue = unserialize($value);
+            if ($returnValue instanceof StorageObject) {
+                $returnValue = $returnValue->value();
+            }
+        }
+
+        return $returnValue;
+    }
+
+    public function save($key, $value, $expiration = null) {
+        if (!is_object($value)) {
+            $value = new StorageObject($value, 0);
+        }
+
+        return (bool) $this->redis->hset($this->hashName, $key, serialize($value));
+    }
+
+    public function clear() {
+        return (bool) $this->redis->del($this->hashName);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "suggest": {
+        "ext-redis": "phpredis extension allows to use the Redis storage",
+        "predis/predis": "predis library allows to use the Redis storage"
+    },
     "require-dev": {
         "phpunit/phpunit": "*"
     }

--- a/tests/PHPUnit/WURFL/Storage/RedisTest.php
+++ b/tests/PHPUnit/WURFL/Storage/RedisTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * test case
+ */
+
+/**
+ * test case.
+ */
+class WURFL_Storage_RedisTest extends PHPUnit_Framework_TestCase {
+
+    public function setUp()
+    {
+        if (!extension_loaded('redis') && !class_exists('\Predis\Client')) {
+            $this->markTestSkipped('Predis library and Redis extension not present');
+        }
+    }
+
+    public function testValidPhpRedisInstance()
+    {
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('Redis extension not present');
+        }
+        $params = array();
+        $mockRedis = $this->getMock('\Redis');
+        $params['redis'] = $mockRedis;
+        $redisStorage = new WURFL_Storage_Redis($params);
+        $this->assertInstanceOf('WURFL_Storage_Redis', $redisStorage);
+    }
+
+    /**
+     * @requires class_exists('\Predis\Client')
+     */
+    public function testValidPredisInstance()
+    {
+        if (!class_exists('\Predis\Client')) {
+            $this->markTestSkipped('Predis library not present');
+        }
+        $mockRedis = $this->getMock('\Predis\Client');
+        $params['redis'] = $mockRedis;
+        $redisStorage = new WURFL_Storage_Redis($params);
+        $this->assertInstanceOf('WURFL_Storage_Redis', $redisStorage);
+    }
+
+    /**
+     * @expectedException WURFL_Storage_Exception
+     * @expectedExceptionMessage Connection object is not a Redis or a Predis\Client instance
+     */
+    public function testInvalidRedisInstance()
+    {
+        $params = array();
+        $params['redis'] = new stdClass();
+        $redisStorage = new WURFL_Storage_Redis($params);
+    }
+
+
+    public function testParametersAreOverridden()
+    {
+        $params = array();
+        $params['redis'] = $this->getMockRedisObject();
+        $params['host'] = '129.0.0.1';
+        $params['port'] = '7654';
+        $params['database'] = 2;
+        $params['hash_name'] = 'WURFL_DATA_TEST';
+        $params['client'] = 'predis';
+
+        $redisStorage = new WURFL_Storage_Redis($params);
+        $this->assertInstanceOf('WURFL_Storage_Redis', $redisStorage);
+
+    }
+
+    /**
+     * @expectedException WURFL_Storage_Exception
+     */
+    public function testWrongClient()
+    {
+        $params = array();
+        $params['host'] = '127.0.0.1';
+        $params['port'] = '6379';
+        $params['database'] = 2;
+        $params['hash_name'] = 'WURFL_DATA_TEST';
+        $params['client'] = 'FAIL';
+
+        $redisStorage = new WURFL_Storage_Redis($params);
+    }
+
+    public function testParametersAreLoaded()
+    {
+        if (class_exists('\Predis\Client')) {
+            $params = array();
+            $params['host'] = '127.0.0.1';
+            $params['port'] = '6379';
+            $params['database'] = 2;
+            $params['hash_name'] = 'WURFL_DATA_TEST';
+            $params['client'] = 'predis';
+
+            try {
+                $redisStorage = new WURFL_Storage_Redis($params);
+                $this->assertInstanceOf('WURFL_Storage_Redis', $redisStorage);
+            } catch (\Predis\Connection\ConnectionException $e) {
+                $this->markTestIncomplete(
+                    'Could not establish connection to Redis using Predis - This test only works' .
+                    'with the standard address of 127.0.0.1:6379 for the Redis server'
+                );
+            }
+        }
+        if (class_exists('\Redis')) {
+            $params = array();
+            $params['host'] = '127.0.0.1';
+            $params['port'] = '6379';
+            $params['database'] = 2;
+            $params['hash_name'] = 'WURFL_DATA_TEST';
+            $params['client'] = 'phpredis';
+
+            try {
+                $redisStorage = new WURFL_Storage_Redis($params);
+                $this->assertInstanceOf('WURFL_Storage_Redis', $redisStorage);
+            } catch (\RedisException $e) {
+                $this->markTestIncomplete(
+                    'Could not establish connection to Redis using phpredis. This test only works' .
+                    'with the standard address of 127.0.0.1:6379 for the Redis server'
+                );
+            }
+        }
+    }
+
+    public function testSaveAndLoadObject()
+    {
+        $value = new stdClass();
+        $value->value = 1;
+        $mockRedis = $this->getMockRedisObject();
+        $mockRedis
+            ->expects($this->once())
+            ->method('hset')
+            ->with(
+                $this->equalTo('FAKE'),
+                $this->equalTo('TEST'),
+                $this->equalTo(serialize($value))
+            )
+            ->willReturn(true);
+
+        $mockRedis
+            ->expects($this->once())
+            ->method('hget')
+            ->with(
+                $this->equalTo('FAKE'),
+                $this->equalTo('TEST')
+            )
+            ->willReturn(serialize($value));
+
+        $params = array();
+        $params['redis'] = $mockRedis;
+        $params['hash_name'] = 'FAKE';
+
+        $redisStorage = new WURFL_Storage_Redis($params);
+        $this->assertTrue($redisStorage->save('TEST', $value, null), 'Save failed');
+        $this->assertEquals($value, $redisStorage->load('TEST', $value), 'Save failed');
+    }
+
+    public function testSaveAndLoadValue()
+    {
+        $value = 1;
+        $object = new StorageObject($value, 0);
+        $mockRedis = $this->getMockRedisObject();
+        $mockRedis
+            ->expects($this->once())
+            ->method('hset')
+            ->with(
+                $this->equalTo('FAKE'),
+                $this->equalTo('TEST_VALUE_STORAGE_OBJECT'),
+                serialize($object)
+            )
+            ->willReturn(true);
+
+        $mockRedis
+            ->expects($this->once())
+            ->method('hget')
+            ->with(
+                $this->equalTo('FAKE'),
+                $this->equalTo('TEST_VALUE_STORAGE_OBJECT')
+            )
+            ->willReturn(serialize($object));
+
+        $params = array();
+        $params['redis'] = $mockRedis;
+        $params['hash_name'] = 'FAKE';
+
+        $redisStorage = new WURFL_Storage_Redis($params);
+        $this->assertTrue(
+            $redisStorage->save('TEST_VALUE_STORAGE_OBJECT', $value, null),
+            'Save failed with StorageObject'
+        );
+        $this->assertEquals(
+            $value,
+            $redisStorage->load('TEST_VALUE_STORAGE_OBJECT', $value),
+            'Load failed with StorageObject'
+        );
+    }
+
+    public function testClear()
+    {
+        $mockRedis = $this->getMockRedisObject();
+        $mockRedis
+            ->expects($this->once())
+            ->method('del')
+            ->with(
+                $this->equalTo('FAKE')
+            )
+            ->willReturn(true);
+
+        $params = array();
+        $params['redis'] = $mockRedis;
+        $params['hash_name'] = 'FAKE';
+
+        $redisStorage = new WURFL_Storage_Redis($params);
+        $this->assertTrue($redisStorage->clear(), 'Clear failed');
+    }
+
+
+    /**
+     * Returns a Predis\Client if predis is present, or Redis object if predis is absent
+     * and redis extension is present
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMockRedisObject()
+    {
+        if (class_exists('\Predis\Client')) {
+            $mockRedis = $this->getMockBuilder('\Predis\Client')
+                ->setMethods(array('hset', 'hget', 'del'))
+                ->getMock();
+        } elseif (extension_loaded('redis')) {
+            $mockRedis = $this->getMockBuilder('\Redis')
+                ->setMethods(array('hset', 'hget', 'del'))
+                ->getMock();
+        }
+
+        return $mockRedis;
+    }
+}


### PR DESCRIPTION
Add new storage for Redis.

- Checks that the redis extension or the predis library is present

- Options for the config: 

```
host:      the redis host. Default 127.0.0.1
port:      the redis port. Default 6379
database:  the redis database. Default 0
hash_name: The hash name for redis. Default WURFL_DATA
redis:     a Redis instance fully configured (connected and with the correct 
	       database selected). Default null. If present overrides all the 
	       other parameters.
client:    redis or predis
```

Example:
```
$wurflConfig->persistence('redis', array('host' => 127.0.0.10, 'port' => 6379, 'hash_name' => 'MY_WURLF_DATA', 'database' => 10, 'client' => 'redis'));
```